### PR TITLE
Replace HTTP with HTTPS

### DIFF
--- a/lib/thepiratebay/search.rb
+++ b/lib/thepiratebay/search.rb
@@ -10,7 +10,7 @@ module ThePirateBay
     def initialize(query, page = 0, sort_by = 99, category = 0)
 
       query = URI.escape(query)
-      doc = Nokogiri::HTML(open('http://thepiratebay.org/search/' + query + '/' + page.to_s + '/' + sort_by.to_s + '/' + category.to_s + ''))
+      doc = Nokogiri::HTML(open('https://thepiratebay.org/search/' + query + '/' + page.to_s + '/' + sort_by.to_s + '/' + category.to_s + ''))
       torrents = []
 
       doc.css('#searchResult tr').each do |row|

--- a/lib/thepiratebay/torrent.rb
+++ b/lib/thepiratebay/torrent.rb
@@ -5,7 +5,7 @@ module ThePirateBay
   class Torrent
     def self.find(torrent_id)
 
-      doc = Nokogiri::HTML(open('http://thepiratebay.org/torrent/' + torrent_id.to_s))
+      doc = Nokogiri::HTML(open('https://thepiratebay.org/torrent/' + torrent_id.to_s))
 
       dd_cache = contents.search('#details dd').select{|dd| is_a_number?(dd.text) }
 

--- a/thepiratebay.gemspec
+++ b/thepiratebay.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name              = %q{thepiratebay}
-  s.version           = '0.2.0'
+  s.version           = '0.2.1'
   s.summary           = %q{A simple interface to ThePirateBay.org}
   s.description       = %q{A simple interface to ThePirateBay.org}
   s.files             = `git ls-files`.split("\n")
@@ -11,7 +11,7 @@ spec = Gem::Specification.new do |s|
   s.authors           = ["Emanuel Andersson"]
   s.date              = %q{2012-03-25}
   s.email             = %q{manusdude@gmail.com}
-  s.homepage          = %q{http://github.com/emnl/thepiratebay}
+  s.homepage          = %q{https://github.com/emnl/thepiratebay}
 
   s.add_dependency "nokogiri"
   # s.add_development_dependency "rspec" # I'll save this one for later.


### PR DESCRIPTION
TPB now redirects to https, which leads to open-uri errors